### PR TITLE
fix(ScrollCollapse): recalculate offsetHeight and offsetTop on resize

### DIFF
--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -20,60 +20,72 @@ describe('ScrollCollapse Lib E2E Tests', function() {
       });
   });
 
-  describe('scroll direction', () => {
-    it('should add scrolling direction class', () => {
-      page.scrollTo();
-      expect(page.getNavElement().getAttribute('class')).not.toContain(
-        'sn-scrolling-down'
-      );
-      expect(page.getNavElement().getAttribute('class')).not.toContain(
-        'sn-scrolling-up'
-      );
+  const runTests = (height = 768) => {
+    describe('scroll direction', () => {
+      it('should add scrolling direction class', () => {
+        page.scrollTo();
+        expect(page.getNavElement().getAttribute('class')).not.toContain(
+          'sn-scrolling-down',
+        );
+        expect(page.getNavElement().getAttribute('class')).not.toContain(
+          'sn-scrolling-up',
+        );
 
-      page.scrollTo(0, 10);
-      page.scrollTo(0, 200);
-      expect(page.getNavElement().getAttribute('class')).toContain(
-        'sn-scrolling-down'
-      );
-      expect(page.getNavElement().getAttribute('class')).not.toContain(
-        'sn-scrolling-up'
-      );
+        page.scrollTo(0, 10);
+        page.scrollTo(0, 200);
+        expect(page.getNavElement().getAttribute('class')).toContain(
+          'sn-scrolling-down',
+        );
+        expect(page.getNavElement().getAttribute('class')).not.toContain(
+          'sn-scrolling-up',
+        );
 
-      page.scrollTo(0, 100);
-      expect(page.getNavElement().getAttribute('class')).not.toContain(
-        'sn-scrolling-down'
-      );
-      expect(page.getNavElement().getAttribute('class')).toContain(
-        'sn-scrolling-up'
-      );
+        page.scrollTo(0, 100);
+        expect(page.getNavElement().getAttribute('class')).not.toContain(
+          'sn-scrolling-down',
+        );
+        expect(page.getNavElement().getAttribute('class')).toContain(
+          'sn-scrolling-up',
+        );
+      });
     });
-  });
 
-  describe('minimise mode', () => {
-    it('should add "sn-minimise" class', () => {
-      page.scrollTo();
-      page.scrollTo(0, 10);
-      expect(page.getNavElement().getAttribute('class')).not.toContain(
-        'sn-minimise'
-      );
+    describe('minimise mode', () => {
+      it('should add "sn-minimise" class', () => {
+        page.scrollTo();
+        page.scrollTo(0, 10);
+        expect(page.getNavElement().getAttribute('class')).not.toContain(
+          'sn-minimise',
+        );
 
-      page.scrollTo(0, 110);
-      expect(page.getNavElement().getAttribute('class')).toContain(
-        'sn-minimise'
-      );
+        page.scrollTo(0, 110);
+        expect(page.getNavElement().getAttribute('class')).toContain(
+          'sn-minimise',
+        );
+      });
     });
-  });
 
-  describe('affix mode', () => {
-    it('should add "sn-affix" class', () => {
-      page.scrollTo();
-      page.scrollTo(0, 10);
-      expect(page.getBarElement().getAttribute('class')).not.toContain(
-        'sn-affix'
-      );
+    describe('affix mode', () => {
+      it('should add "sn-affix" class', () => {
+        page.scrollTo();
+        page.scrollTo(0, 10);
+        expect(page.getBarElement().getAttribute('class')).not.toContain(
+          'sn-affix',
+        );
 
-      page.scrollTo(0, 768 * 3);
-      expect(page.getBarElement().getAttribute('class')).toContain('sn-affix');
+        page.scrollTo(0, height * 3);
+        expect(page.getBarElement().getAttribute('class')).toContain(
+          'sn-affix',
+        );
+      });
     });
+  };
+
+  runTests();
+
+  describe('resize', () => {
+    beforeEach(() => page.resize(1024, 600));
+
+    runTests(600);
   });
 });

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -10,6 +10,14 @@ export class AppPage {
     browser.sleep(100);
   }
 
+  resize(width: number, height: number) {
+    browser.driver
+      .manage()
+      .window()
+      .setSize(width, height);
+    browser.sleep(100);
+  }
+
   getNavElement() {
     return element(by.css('.nav'));
   }


### PR DESCRIPTION
fixed an issue where if the browser is resized then the minimise and affix states would not be
recalculated correctly

Fix #22