### PR TITLE
fix(ScrollCollapse): minimise state not set correctly on page load

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,11 @@
-import { Component } from '@angular/core';
-import { Direction } from '..';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Direction } from './scroll-collapse/shared/direction.enum';
 
 @Component({
   selector: 'sn-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {
   scrollDirectionHandler(event: Direction) {

--- a/src/app/scroll-collapse/scroll-collapse.directive.ts
+++ b/src/app/scroll-collapse/scroll-collapse.directive.ts
@@ -189,6 +189,7 @@ export class ScrollCollapseDirective implements AfterViewInit, OnDestroy {
     this.calculateScrollDirection([previousEvent, currentEvent]);
     this.calculateMinimiseMode(currentEvent);
     this.calculateAffixMode(currentEvent);
+    this.cdRef.detectChanges();
   }
   /**
    * Remove minimise, affix and scrolling states and recalulate


### PR DESCRIPTION
Fixed a bug when using OnPush change detection where minimise state was not being set correctly on
page load and scroll position is not at the top of the page

Fix #21